### PR TITLE
PDFDomTree font extract options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,18 +145,17 @@
 		<dependency>
 			<groupId>org.fontverter</groupId>
 			<artifactId>FontVerter</artifactId>
-			<version>1.2</version>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.11</version>
-			<scope>test</scope>
+			<version>1.2.9</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>2.4</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/org/fit/pdfdom/FontTable.java
+++ b/src/main/java/org/fit/pdfdom/FontTable.java
@@ -59,6 +59,7 @@ public class FontTable extends HashMap<String, FontTable.Entry>
 
         private byte[] cachedFontData;
         private String mimeType = "x-font-truetype";
+        private String fileEnding;
 
         public Entry(String fontName, String usedName, PDFontDescriptor descriptor)
         {
@@ -73,8 +74,9 @@ public class FontTable extends HashMap<String, FontTable.Entry>
             if (getFontData() != null)
                 cdata = Base64Coder.encode(getFontData());
 
-            return String.format("data:application/%s;base64,%s", mimeType, new String(cdata));
+            return String.format("data:%s;base64,%s", mimeType, new String(cdata));
         }
+
 
         public byte[] getFontData() throws IOException
         {
@@ -109,7 +111,8 @@ public class FontTable extends HashMap<String, FontTable.Entry>
         {
             // otf/OpenType/ttf/TrueType can be used as is by browsers, could convert to WOFF though for
             // optimal html output.
-            mimeType = "x-font-truetype";
+            mimeType = "application/x-font-truetype";
+            fileEnding = "otf";
             return fontFile.toByteArray();
         }
 
@@ -126,7 +129,8 @@ public class FontTable extends HashMap<String, FontTable.Entry>
             try
             {
                 FVFont font = FontVerter.convertFont(fontFile.toByteArray(), FontVerter.FontFormat.WOFF1);
-                mimeType = "x-font-woff";
+                mimeType = "application/x-font-woff";
+                fileEnding = font.getProperties().getFileEnding();
 
                 return font.getData();
             } catch (Exception ex) {
@@ -160,11 +164,14 @@ public class FontTable extends HashMap<String, FontTable.Entry>
             return true;
         }
 
+        public String getFileEnding()
+        {
+            return fileEnding;
+        }
+
         private FontTable getOuterType()
         {
             return FontTable.this;
         }
-
     }
-
 }

--- a/src/main/java/org/fit/pdfdom/PDFDomTreeConfig.java
+++ b/src/main/java/org/fit/pdfdom/PDFDomTreeConfig.java
@@ -1,0 +1,45 @@
+package org.fit.pdfdom;
+
+import java.io.File;
+
+public class PDFDomTreeConfig
+{
+    private FontExtractMode fontMode;
+    private File fontExtractDirectory;
+
+    public static PDFDomTreeConfig createDefaultConfig() {
+        PDFDomTreeConfig config = new PDFDomTreeConfig();
+        config.fontMode = FontExtractMode.EMBED_BASE64;
+
+        return config;
+    }
+
+    private PDFDomTreeConfig() {
+    }
+
+    public FontExtractMode getFontMode()
+    {
+        return fontMode;
+    }
+
+    public void setFontMode(FontExtractMode fontMode)
+    {
+        this.fontMode = fontMode;
+    }
+
+    public File getFontExtractDirectory()
+    {
+        return fontExtractDirectory;
+    }
+
+    public void setFontExtractDirectory(File fontExtractDirectory)
+    {
+        this.fontExtractDirectory = fontExtractDirectory;
+    }
+
+    public enum FontExtractMode {
+        EMBED_BASE64,
+        SAVE_TO_DIR,
+        IGNORE_FONTS
+    }
+}

--- a/src/test/java/org/fit/pdfdom/TestFonts.java
+++ b/src/test/java/org/fit/pdfdom/TestFonts.java
@@ -4,14 +4,19 @@ import org.apache.commons.codec.binary.Base64;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mabb.fontverter.woff.WoffFont;
 import org.mabb.fontverter.woff.WoffParser;
 
+import java.io.File;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.fit.pdfdom.PDFDomTreeConfig.FontExtractMode.*;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.greaterThan;
 
 public class TestFonts
@@ -51,5 +56,49 @@ public class TestFonts
         String divStyle = div.attr("style");
 
         Assert.assertThat(divStyle, containsString("font-family:"));
+    }
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void convertPdf_withFontExtractToDirModeSet_thenFontFaceRuleHasUrlToFile() throws Exception
+    {
+        Document html = convertWithFontSaveToDirMode("/fonts/bare-cff.pdf");
+        Element style = html.select("style").get(0);
+
+        Assert.assertThat(style.outerHtml(), containsString("font-extract-dir/EKCFJL+Omsym2.woff"));
+    }
+
+    @Test
+    public void convertPdf_withFontExtractToDirModeSet_thenFontFileExists() throws Exception
+    {
+        Document html = convertWithFontSaveToDirMode("/fonts/bare-cff.pdf");
+        File tempFontFile = new File(folder.getRoot().getPath() + "/font-extract-dir/EKCFJL+Omsym2.woff");
+
+        Assert.assertTrue(tempFontFile.exists());
+    }
+
+    @Test
+    public void convertPdf_withIgnoreFontsModeSet_thenNoFontFacesInHtml() throws Exception
+    {
+        PDFDomTreeConfig config = PDFDomTreeConfig.createDefaultConfig();
+        config.setFontMode(IGNORE_FONTS);
+
+        Document html  = TestUtils.parseWithPdfDomTree("/fonts/bare-cff.pdf", config);
+        Element style = html.select("style").get(0);
+
+        Assert.assertThat(style.outerHtml(), not(containsString("@font-face")));
+    }
+
+    private Document convertWithFontSaveToDirMode(String pdf) throws Exception
+    {
+        File fontDir = folder.newFolder("font-extract-dir");
+
+        PDFDomTreeConfig config = PDFDomTreeConfig.createDefaultConfig();
+        config.setFontExtractDirectory(fontDir);
+        config.setFontMode(SAVE_TO_DIR);
+
+        return TestUtils.parseWithPdfDomTree(pdf, config);
     }
 }

--- a/src/test/java/org/fit/pdfdom/TestUtils.java
+++ b/src/test/java/org/fit/pdfdom/TestUtils.java
@@ -16,23 +16,32 @@ import static org.hamcrest.number.OrderingComparison.lessThan;
 
 public class TestUtils
 {
-    public static Document parseWithPdfDomTree(String resource)
-            throws IOException, ParserConfigurationException, TransformerException
+    public static Document parseWithPdfDomTree(String resource) throws Exception
+    {
+        return parseWithPdfDomTree(resource, PDFDomTreeConfig.createDefaultConfig());
+    }
+
+    public static Document parseWithPdfDomTree(String resource, PDFDomTreeConfig config) throws Exception
     {
         InputStream is = TestUtils.class.getResourceAsStream(resource);
-        Document doc = parseWithPdfDomTree(is);
+        Document doc = parseWithPdfDomTree(is, config);
         is.close();
-//        File debugOutFile = new File(resource.replace(".pdf", ".html").replaceAll(".*/",""));
-//        FileUtils.write(debugOutFile, doc.outerHtml());
+        // File debugOutFile = new File(resource.replace(".pdf", ".html").replaceAll(".*/",""));
+        // FileUtils.write(debugOutFile, doc.outerHtml());
 
         return doc;
     }
 
-    public static Document parseWithPdfDomTree(InputStream is)
+    public static Document parseWithPdfDomTree(InputStream is) throws Exception
+    {
+        return parseWithPdfDomTree(is, PDFDomTreeConfig.createDefaultConfig());
+    }
+
+    public static Document parseWithPdfDomTree(InputStream is, PDFDomTreeConfig config)
             throws IOException, ParserConfigurationException, TransformerException
     {
         PDDocument pdf = PDDocument.load(is);
-        PDFDomTree parser = new PDFDomTree();
+        PDFDomTree parser = new PDFDomTree(config);
 
         Writer output = new StringWriter();
         parser.writeText(pdf, output);


### PR DESCRIPTION
Adds PDFDomTree font extract modes for embedding fonts, saving fonts to disk and ignoring pdf fonts completely.

**Usage:**
```
PDFDomTreeConfig config = PDFDomTreeConfig.createDefaultConfig();
config.setFontExtractDirectory(fontDir);
config.setFontMode(SAVE_TO_DIR);

PDFDomTree parser = new PDFDomTree(config);
```

**Modes are:**
EMBED_BASE64,
SAVE_TO_DIR,
IGNORE_FONTS


  
