### PR TITLE
Normalize TTF and Type0+TTF fonts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
 		<dependency>
 			<groupId>org.fontverter</groupId>
 			<artifactId>FontVerter</artifactId>
-			<version>1.2</version>
+			<version>1.2.10</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/org/fit/pdfdom/PDFBoxTree.java
+++ b/src/main/java/org/fit/pdfdom/PDFBoxTree.java
@@ -380,7 +380,7 @@ public abstract class PDFBoxTree extends PDFTextStripper
             {
                 PDCIDFont descendantFont = ((PDType0Font) font).getDescendantFont();
                 if (descendantFont instanceof PDCIDFontType2)
-                    table.addEntry(font.getName(), descendantFont.getFontDescriptor());
+                    table.addEntry(font.getName(), font);
                 else
                     log.warn(fontNotSupportedMessage, font.getName(), font.getClass().getSimpleName());
             }


### PR DESCRIPTION
As discussed in pull request #8, some TTF and Type0+TTF fonts coming straight from pdf's give font validation errors in some browsers.

This pull request changes FontTable to run them through FontVerter's font normalization. The relevant fonts in brno30.pdf and HorariosMadrid_Segovia.pdf now seem to render correctly and there are no longer any font validation errors with them in Chrome, IE and FireFox,.