### PR TITLE
Use actual font name in @font-face rules instead of F[n] naming

### DIFF
--- a/src/main/java/org/fit/pdfdom/PDFBoxTree.java
+++ b/src/main/java/org/fit/pdfdom/PDFBoxTree.java
@@ -373,19 +373,19 @@ public abstract class PDFBoxTree extends PDFTextStripper
             PDFont font = resources.getFont(key);
             if (font instanceof PDTrueTypeFont)
             {
-                table.addEntry(font.getName(), font.getFontDescriptor());
+                table.addEntry( font);
                 log.debug("Font: " + font.getName() + " TTF");
             }
             else if (font instanceof PDType0Font)
             {
                 PDCIDFont descendantFont = ((PDType0Font) font).getDescendantFont();
                 if (descendantFont instanceof PDCIDFontType2)
-                    table.addEntry(font.getName(), font);
+                    table.addEntry(font);
                 else
                     log.warn(fontNotSupportedMessage, font.getName(), font.getClass().getSimpleName());
             }
             else if (font instanceof PDType1CFont)
-                table.addEntry(font.getName(), font.getFontDescriptor());
+                table.addEntry(font);
             else
                 log.warn(fontNotSupportedMessage, font.getName(), font.getClass().getSimpleName());
         }
@@ -725,7 +725,7 @@ public abstract class PDFBoxTree extends PDFTextStripper
                 family = knownFontFamily;
             else
             {
-                family = fontTable.getUsedName(font);
+                family = fontTable.getUsedName(text.getFont());
                 if (family == null)
                     family = font;
             }

--- a/src/main/java/org/fit/pdfdom/PDFDomTree.java
+++ b/src/main/java/org/fit/pdfdom/PDFDomTree.java
@@ -538,7 +538,7 @@ public class PDFDomTree extends PDFBoxTree
     protected String createFontFaces()
     {
         StringBuilder ret = new StringBuilder();
-        for (FontTable.Entry font : fontTable.values())
+        for (FontTable.Entry font : fontTable.getEntries())
         {
             switch(config.getFontMode()) {
                 case EMBED_BASE64:


### PR DESCRIPTION
This pull request changes FontTable to use the actual font name instead of the existing F[n] naming, mostly useful for debugging html output with many fonts but also makes the generated html cleaner looking in actual usage. 