### PR TITLE
Fix for matching fonts, incorrectly returns "Arial" instead of "Arial Narrow"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
 	<groupId>net.sf.cssbox</groupId>
 	<artifactId>pdf2dom</artifactId>
-	<version>1.8-SNAPSHOT</version>
+	<version>1.7-SNAPSHOT</version>
 	<name>Pdf2Dom</name>
 	<description>Pdf2Dom is a PDF parser that converts the documents to a HTML DOM representation. The obtained DOM tree may be then serialized to a HTML file or further processed. The inline CSS definitions contained in the resulting document are used for making the HTML page as similar as possible to the PDF input. A command-line utility for converting the PDF documents to HTML is included in the distribution package. Pdf2Dom may be also used as an independent Java library with a standard DOM interface for your DOM-based applications or as an alternative parser for the CSSBox rendering engine in order to add the PDF processing capability to CSSBox.</description>
 	<url>http://cssbox.sourceforge.net/pdf2dom</url>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
 	<groupId>net.sf.cssbox</groupId>
 	<artifactId>pdf2dom</artifactId>
-	<version>1.7-SNAPSHOT</version>
+	<version>1.8-SNAPSHOT</version>
 	<name>Pdf2Dom</name>
 	<description>Pdf2Dom is a PDF parser that converts the documents to a HTML DOM representation. The obtained DOM tree may be then serialized to a HTML file or further processed. The inline CSS definitions contained in the resulting document are used for making the HTML page as similar as possible to the PDF input. A command-line utility for converting the PDF documents to HTML is included in the distribution package. Pdf2Dom may be also used as an independent Java library with a standard DOM interface for your DOM-based applications or as an alternative parser for the CSSBox rendering engine in order to add the PDF processing capability to CSSBox.</description>
 	<url>http://cssbox.sourceforge.net/pdf2dom</url>

--- a/src/main/java/org/fit/pdfdom/PDFBoxTree.java
+++ b/src/main/java/org/fit/pdfdom/PDFBoxTree.java
@@ -88,7 +88,7 @@ public abstract class PDFBoxTree extends PDFTextStripper
     public static final String UNIT = "pt";
 
     /** Known font names that are recognized in the PDF files */
-    protected static String[] cssFontFamily = { "Times New Roman", "Times", "Garamond", "Helvetica", "Arial", "Arial Narrow", "Verdana", "Courier New", "MS Sans Serif" };
+    protected static String[] cssFontFamily = { "Times New Roman", "Times", "Garamond", "Helvetica", "Arial Narrow", "Arial", "Verdana", "Courier New", "MS Sans Serif" };
 
     /** Known font subtypes recognized in PDF files */
     protected static String[] pdFontType =    { "normal", "roman",  "bold",   "italic", "bolditalic" };
@@ -756,7 +756,7 @@ public abstract class PDFBoxTree extends PDFTextStripper
     private String findKnownFontFamily(String font) {
         for (String fontFamilyOn : cssFontFamily)
         {
-            if (font.toLowerCase().equals(fontFamilyOn.toLowerCase()))
+            if (font.toLowerCase().lastIndexOf(fontFamilyOn.toLowerCase().replaceAll("\\s+","")) >= 0)
                 return fontFamilyOn;
         }
 

--- a/src/main/java/org/fit/pdfdom/PDFBoxTree.java
+++ b/src/main/java/org/fit/pdfdom/PDFBoxTree.java
@@ -756,7 +756,7 @@ public abstract class PDFBoxTree extends PDFTextStripper
     private String findKnownFontFamily(String font) {
         for (String fontFamilyOn : cssFontFamily)
         {
-            if (font.toLowerCase().lastIndexOf(fontFamilyOn.toLowerCase()) >= 0)
+            if (font.toLowerCase().equals(fontFamilyOn.toLowerCase()))
                 return fontFamilyOn;
         }
 


### PR DESCRIPTION
<img width="1674" alt="pdf2dom-fonts-test" src="https://cloud.githubusercontent.com/assets/12503737/24121304/1368b176-0d75-11e7-959f-fc98b427cbe3.png">
