### PR TITLE
bump fontverter version to fix missing jade dependency issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
 		<dependency>
 			<groupId>net.mabboud.fontverter</groupId>
 			<artifactId>FontVerter</artifactId>
-			<version>1.2.18</version>
+			<version>1.2.20</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>


### PR DESCRIPTION
For issue #20 