### PR TITLE
Handling the exceptions if fontvetter not supporting a TrueTypeFont like Hevertica etc..

### DIFF
--- a/src/main/java/org/fit/pdfdom/FontTable.java
+++ b/src/main/java/org/fit/pdfdom/FontTable.java
@@ -176,10 +176,15 @@ public class FontTable
             fileEnding = "otf";
 
             byte[] fontData = fontFile.toByteArray();
+            byte[] fvFontData = null;
+            try {
+                FVFont font = FontVerter.readFont(fontData);
+                fvFontData = tryNormalizeFVFont(font);
+            } catch (IOException e) {
+                log.warn("Unsupported FontFile found. Normalisation will be skipped.");
+            }
 
-            FVFont font = FontVerter.readFont(fontData);
-            byte[] fvFontData = tryNormalizeFVFont(font);
-            if (fvFontData.length != 0)
+            if (fvFontData != null && fvFontData.length != 0)
                 fontData = fvFontData;
 
             return fontData;


### PR DESCRIPTION
… need to rethrow that exception as it will clear the entire font info making the method return null..

This can fix most of the spacing issues in unsupported font case..